### PR TITLE
Add interactive CLI chat

### DIFF
--- a/HF_CLI_MCP_Scenario.md
+++ b/HF_CLI_MCP_Scenario.md
@@ -3,7 +3,8 @@
 This document describes an agentic workflow for interacting with the Hugging Face CLI using the patterns from `agents.md`. It consists of two stages:
 
 1. **CLI Chat** – a single agent (`HFCLIExecutor`) logs in and performs a small command like `whoami`.
-2. **Full MCP** – the same agent is orchestrated to run multiple commands (`models list` and `datasets list`) in parallel. Session state such as the HF token is stored on disk so the agent can resume in future runs.
+2. **Full MCP** – the same agent runs multiple commands (`models list` and `datasets list`) in parallel.
+3. **Chat Delegation** – a `HFChatAgent` converses with the user and hands off requests to `HFCLIExecutor`.
 
 ## Agent Implementation
 
@@ -13,18 +14,19 @@ class HFCLIExecutor(Agent):
     name = "HF-CLI-EXECUTOR"
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.memory.setdefault("hf_token", None)
+        super().__init__(name=self.name, tools=[], *args, **kwargs)
+        self.session = {}
+        self.session.setdefault("hf_token", None)
         self._load_session()
 
     def _load_session(self):
         if os.path.exists(SESSION_FILE):
             with open(SESSION_FILE, "r") as f:
-                self.memory.update(json.load(f))
+                self.session.update(json.load(f))
 
     def _save_session(self):
         with open(SESSION_FILE, "w") as f:
-            json.dump(self.memory, f)
+            json.dump(self.session, f)
 ```
 
 `_load_session()` and `_save_session()` keep the HF token and other memory across runs.
@@ -40,12 +42,13 @@ async def run_hf_cli(self, cmd: str, args: list[str] = None) -> dict:
     ...  # parse stdout/stderr as shown in agents.md
 ```
 
-The `cli_chat()` coroutine logs in (if needed), runs `whoami`, and prints the result. `full_mcp()` triggers several CLI commands concurrently. See `hf_cli_scenarios.py` for details.
+The `cli_chat()` coroutine logs in (if needed), runs `whoami`, and prints the result. `full_mcp()` triggers several CLI commands concurrently. `chat_with_agents()` demonstrates delegating user requests from `HFChatAgent` to `HFCLIExecutor` via a handoff. See `hf_cli_scenarios.py` for details.
 
 ## Usage
 
 ```bash
 python hf_cli_scenarios.py <HF_TOKEN>
+python hf_cli_scenarios.py <HF_TOKEN> chat
 ```
 
-On the first run, the token is saved to `session.json`. Subsequent runs reuse the token without prompting for login, demonstrating persistence across sessions.
+On the first run, the token is saved to `session.json`. Subsequent runs reuse the token without prompting for login. The default run prints results for `cli_chat`, `full_mcp`, and a demo `chat_with_agents` conversation. Passing the `chat` argument starts an interactive session with `HFChatAgent`.

--- a/agents.md
+++ b/agents.md
@@ -7,7 +7,9 @@ This guide demonstrates idiomatic patterns for invoking `huggingface-cli` comman
 ## 1. Quick Start Snippet
 
 ```python
-from openai_agents import Agent, tool, run
+from agents import Agent
+from agents.tool import function_tool
+from agents.run import Runner
 import asyncio, json, textwrap
 
 HF_TIMEOUT = 30  # seconds
@@ -15,7 +17,7 @@ HF_TIMEOUT = 30  # seconds
 class HFCLIExecutor(Agent):
     name = "AG-EXEC-CLI"
 
-    @tool(name="run_hf_cli", description="Run huggingface-cli commands")
+    @function_tool(name="run_hf_cli", description="Run huggingface-cli commands")
     async def run_hf_cli(self, cmd: str, args: list[str] = []) -> dict:
         """Execute huggingface‑cli <cmd> <args> and return structured result"""
         proc = await asyncio.create_subprocess_exec(
@@ -47,7 +49,7 @@ class HFCLIExecutor(Agent):
 
 if __name__ == "__main__":
     # ad‑hoc run for local dev
-    print(run(agent=HFCLIExecutor(), instructions="run_hf_cli cmd='whoami'"))
+    print(asyncio.run(Runner.run(agent=HFCLIExecutor(), input="run_hf_cli cmd='whoami'")))
 ```
 
 ### Why this pattern?
@@ -157,6 +159,21 @@ async def test_models_list_json():
     out = await agent.run_hf_cli("models", ["list", "--limit", "1", "--json"])
     assert out["exit"] == 0
     assert isinstance(out["stdout"], list)
+```
+
+## 9. Delegating via Handoff
+
+Use the `handoff()` helper to create a chat agent that delegates CLI work to another agent.
+
+```python
+class HFChatAgent(Agent):
+    def __init__(self, cli_agent: HFCLIExecutor):
+        super().__init__(name="HF-CHAT", tools=[
+            handoff(cli_agent, tool_name_override="hf_cli_agent")
+        ])
+
+# example interactive session
+asyncio.run(Runner.run(HFChatAgent(HFCLIExecutor()), "whoami"))
 ```
 
 ---


### PR DESCRIPTION
## Summary
- document chat mode for CLI scenario
- provide example session for HFChatAgent in docs
- support `chat` argument to start an interactive conversation

## Testing
- `python hf_cli_scenarios.py $HUGGINGFACE_HUB_TOKEN chat` *(fails: ModuleNotFoundError: No module named 'agents')*


------
https://chatgpt.com/codex/tasks/task_e_68604ca78d60832c9193b1c0b5fbb2e9