### PR TITLE
Add interactive memory

### DIFF
--- a/HF_CLI_MCP_Scenario.md
+++ b/HF_CLI_MCP_Scenario.md
@@ -3,7 +3,8 @@
 This document describes an agentic workflow for interacting with the Hugging Face CLI using the patterns from `agents.md`. It consists of two stages:
 
 1. **CLI Chat** – a single agent (`HFCLIExecutor`) logs in and performs a small command like `whoami`.
-2. **Full MCP** – the same agent is orchestrated to run multiple commands (`models list` and `datasets list`) in parallel. Session state such as the HF token is stored on disk so the agent can resume in future runs.
+2. **Full MCP** – the same agent runs multiple commands (`models list` and `datasets list`) in parallel.
+3. **Chat Delegation** – a `HFChatAgent` converses with the user and hands off requests to `HFCLIExecutor`.
 
 ## Agent Implementation
 
@@ -13,18 +14,19 @@ class HFCLIExecutor(Agent):
     name = "HF-CLI-EXECUTOR"
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.memory.setdefault("hf_token", None)
+        super().__init__(name=self.name, tools=[], *args, **kwargs)
+        self.session = {}
+        self.session.setdefault("hf_token", None)
         self._load_session()
 
     def _load_session(self):
         if os.path.exists(SESSION_FILE):
             with open(SESSION_FILE, "r") as f:
-                self.memory.update(json.load(f))
+                self.session.update(json.load(f))
 
     def _save_session(self):
         with open(SESSION_FILE, "w") as f:
-            json.dump(self.memory, f)
+            json.dump(self.session, f)
 ```
 
 `_load_session()` and `_save_session()` keep the HF token and other memory across runs.
@@ -40,12 +42,13 @@ async def run_hf_cli(self, cmd: str, args: list[str] = None) -> dict:
     ...  # parse stdout/stderr as shown in agents.md
 ```
 
-The `cli_chat()` coroutine logs in (if needed), runs `whoami`, and prints the result. `full_mcp()` triggers several CLI commands concurrently. See `hf_cli_scenarios.py` for details.
+The `cli_chat()` coroutine logs in (if needed), runs `whoami`, and prints the result. `full_mcp()` triggers several CLI commands concurrently. `chat_with_agents()` demonstrates delegating user requests from `HFChatAgent` to `HFCLIExecutor` via a handoff. Interactive chat uses `run_demo_loop` from the SDK so conversation history is preserved between turns. See `hf_cli_scenarios.py` for details.
 
 ## Usage
 
 ```bash
 python hf_cli_scenarios.py <HF_TOKEN>
+python hf_cli_scenarios.py <HF_TOKEN> chat
 ```
 
-On the first run, the token is saved to `session.json`. Subsequent runs reuse the token without prompting for login, demonstrating persistence across sessions.
+On the first run, the token is saved to `session.json`. Subsequent runs reuse the token without prompting for login. The default run prints results for `cli_chat`, `full_mcp`, and a demo `chat_with_agents` conversation. Passing the `chat` argument starts an interactive session with `HFChatAgent` that keeps memory across turns.

--- a/agents.md
+++ b/agents.md
@@ -7,7 +7,9 @@ This guide demonstrates idiomatic patterns for invoking `huggingface-cli` comman
 ## 1. Quick Start Snippet
 
 ```python
-from openai_agents import Agent, tool, run
+from agents import Agent
+from agents.tool import function_tool
+from agents.run import Runner
 import asyncio, json, textwrap
 
 HF_TIMEOUT = 30  # seconds
@@ -15,7 +17,7 @@ HF_TIMEOUT = 30  # seconds
 class HFCLIExecutor(Agent):
     name = "AG-EXEC-CLI"
 
-    @tool(name="run_hf_cli", description="Run huggingface-cli commands")
+    @function_tool(name="run_hf_cli", description="Run huggingface-cli commands")
     async def run_hf_cli(self, cmd: str, args: list[str] = []) -> dict:
         """Execute huggingface‑cli <cmd> <args> and return structured result"""
         proc = await asyncio.create_subprocess_exec(
@@ -47,7 +49,7 @@ class HFCLIExecutor(Agent):
 
 if __name__ == "__main__":
     # ad‑hoc run for local dev
-    print(run(agent=HFCLIExecutor(), instructions="run_hf_cli cmd='whoami'"))
+    print(asyncio.run(Runner.run(agent=HFCLIExecutor(), input="run_hf_cli cmd='whoami'")))
 ```
 
 ### Why this pattern?
@@ -157,6 +159,22 @@ async def test_models_list_json():
     out = await agent.run_hf_cli("models", ["list", "--limit", "1", "--json"])
     assert out["exit"] == 0
     assert isinstance(out["stdout"], list)
+```
+
+## 9. Delegating via Handoff
+
+Use the `handoff()` helper to create a chat agent that delegates CLI work to another agent. The SDK's `run_demo_loop` utility preserves conversation history between turns.
+
+```python
+from agents.repl import run_demo_loop
+class HFChatAgent(Agent):
+    def __init__(self, cli_agent: HFCLIExecutor):
+        super().__init__(name="HF-CHAT", tools=[
+            handoff(cli_agent, tool_name_override="hf_cli_agent")
+        ])
+
+# example interactive session with memory
+asyncio.run(run_demo_loop(HFChatAgent(HFCLIExecutor())))
 ```
 
 ---

--- a/hf_cli_scenarios.py
+++ b/hf_cli_scenarios.py
@@ -1,7 +1,10 @@
 import asyncio
 import json
 import os
-from openai_agents import Agent, tool, run
+from agents import Agent, handoff
+from agents.tool import function_tool
+from agents.run import Runner
+from agents.repl import run_demo_loop
 
 HF_TIMEOUT = 30
 SESSION_FILE = "session.json"
@@ -10,20 +13,21 @@ class HFCLIExecutor(Agent):
     name = "HF-CLI-EXECUTOR"
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.memory.setdefault("hf_token", None)
+        super().__init__(name=self.name, tools=[], *args, **kwargs)
+        self.session = {}
+        self.session.setdefault("hf_token", None)
         self._load_session()
+        self.tools.append(function_tool(self.run_hf_cli, name_override="run_hf_cli", description_override="Run huggingface-cli commands"))
 
     def _load_session(self):
         if os.path.exists(SESSION_FILE):
             with open(SESSION_FILE, "r") as f:
-                self.memory.update(json.load(f))
+                self.session.update(json.load(f))
 
     def _save_session(self):
         with open(SESSION_FILE, "w") as f:
-            json.dump(self.memory, f)
+            json.dump(self.session, f)
 
-    @tool(name="run_hf_cli", description="Run huggingface-cli commands")
     async def run_hf_cli(self, cmd: str, args: list[str] = None) -> dict:
         args = args or []
         proc = await asyncio.create_subprocess_exec(
@@ -50,11 +54,27 @@ class HFCLIExecutor(Agent):
         }
         return result
 
+    @function_tool
+    async def list_models(self, author: str | None = None, limit: int = 10) -> list:
+        """List models via huggingface-cli with JSON output"""
+        args = ["list", "--limit", str(limit), "--json"]
+        if author:
+            args.extend(["--author", author])
+        result = await self.run_hf_cli("models", args)
+        return result["stdout"]
+
+    @function_tool
+    async def list_datasets(self, limit: int = 10) -> list:
+        """List datasets via huggingface-cli with JSON output"""
+        args = ["list", "--limit", str(limit), "--json"]
+        result = await self.run_hf_cli("datasets", args)
+        return result["stdout"]
+
     async def ensure_login(self, token: str):
-        if self.memory.get("hf_token") == token:
+        if self.session.get("hf_token") == token:
             return
         await self.run_hf_cli("login", ["--token", token])
-        self.memory["hf_token"] = token
+        self.session["hf_token"] = token
         self._save_session()
 
 async def cli_chat(token: str):
@@ -74,11 +94,49 @@ async def full_mcp(token: str):
     for r in results:
         print(r)
 
+class HFChatAgent(Agent):
+    """Agent that chats with the user and delegates HF CLI work."""
+
+    name = "HF-CHAT-AGENT"
+
+    def __init__(self, hf_agent: HFCLIExecutor, *args, **kwargs):
+        self.hf_agent = hf_agent
+        super().__init__(
+            name=self.name,
+            handoffs=[
+                handoff(
+                    self.hf_agent,
+                    tool_name_override="hf_cli_agent",
+                    tool_description_override="Delegate CLI requests to HF agent",
+                )
+            ],
+            *args,
+            **kwargs,
+        )
+
+async def chat_with_agents(token: str, message: str):
+    hf_agent = HFCLIExecutor()
+    await hf_agent.ensure_login(token)
+    chat_agent = HFChatAgent(hf_agent)
+    result = await Runner.run(chat_agent, message)
+    print(result)
+
 if __name__ == "__main__":
     import sys
     if len(sys.argv) < 2:
-        print("Usage: python hf_cli_scenarios.py <HF_TOKEN>")
+        print("Usage: python hf_cli_scenarios.py <HF_TOKEN> [chat]")
         sys.exit(1)
     token = sys.argv[1]
-    asyncio.run(cli_chat(token))
-    asyncio.run(full_mcp(token))
+    if len(sys.argv) > 2 and sys.argv[2] == "chat":
+        async def interactive():
+            hf_agent = HFCLIExecutor()
+            await hf_agent.ensure_login(token)
+            chat_agent = HFChatAgent(hf_agent)
+            print("Starting interactive chat. Press Ctrl+C to exit.")
+            await run_demo_loop(chat_agent, stream=False)
+
+        asyncio.run(interactive())
+    else:
+        asyncio.run(cli_chat(token))
+        asyncio.run(full_mcp(token))
+        asyncio.run(chat_with_agents(token, "List two models"))


### PR DESCRIPTION
## Summary
- support interactive chat sessions via `run_demo_loop`
- document memory-preserving chat mode in scenario guide
- mention `run_demo_loop` in handoff instructions

## Testing
- `python hf_cli_scenarios.py $HUGGINGFACE_HUB_TOKEN` *(fails: certificate verify failed)*
- `python hf_cli_scenarios.py $HUGGINGFACE_HUB_TOKEN chat` *(stuck waiting for input)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68604ca78d60832c9193b1c0b5fbb2e9